### PR TITLE
server: implement GET /v2/job-types

### DIFF
--- a/db/queries/jobs.sql
+++ b/db/queries/jobs.sql
@@ -8,12 +8,13 @@ VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: GetJob :one
-SELECT *
-FROM jobs
+SELECT * FROM jobs
 WHERE name = $1;
 
 -- name: GetAllJobs :many
-SELECT * FROM jobs WHERE name != 'meta.shutdown';
+SELECT * FROM jobs
+WHERE name != 'meta.shutdown'
+ORDER BY auto_id DESC;
 
 -- name: DeleteAllJobs :execrows
 DELETE FROM jobs;

--- a/dbtohttp/dbtohttp.go
+++ b/dbtohttp/dbtohttp.go
@@ -1,0 +1,24 @@
+package dbtohttp
+
+import (
+	"github.com/kevinburke/rickover/newmodels"
+	"github.com/kevinburke/rickover/responses"
+)
+
+func Job(j newmodels.Job) responses.Job {
+	return responses.Job{
+		Name:             j.Name,
+		DeliveryStrategy: string(j.DeliveryStrategy),
+		Attempts:         j.Attempts,
+		Concurrency:      j.Concurrency,
+		CreatedAt:        j.CreatedAt,
+	}
+}
+
+func Jobs(js []newmodels.Job) []responses.Job {
+	resp := make([]responses.Job, len(js))
+	for i := range js {
+		resp[i] = Job(js[i])
+	}
+	return resp
+}

--- a/models/queued_jobs/queued_jobs.go
+++ b/models/queued_jobs/queued_jobs.go
@@ -39,6 +39,8 @@ var StuckJobLimit = 100
 // Enqueue creates a new queued job with the given ID and fields. A
 // sql.ErrNoRows will be returned if the `name` does not exist in the jobs
 // table. Otherwise the QueuedJob will be returned.
+//
+// Deprecated: use services.Enqueue instead.
 func Enqueue(params newmodels.EnqueueJobParams) (*newmodels.QueuedJob, error) {
 	qj, err := newmodels.DB.EnqueueJob(context.TODO(), params)
 	if err != nil {

--- a/newmodels/setup.go
+++ b/newmodels/setup.go
@@ -7,14 +7,18 @@ import (
 	"github.com/kevinburke/rickover/models/db"
 )
 
-var DB *Queries
+// DefaultServer relies on this being initialized (and not overwritten)
+var DB = new(Queries)
 
 func Setup(ctx context.Context) error {
 	if !db.Connected() {
 		return errors.New("newmodels: no database connection, bailing")
 	}
 
-	var err error
-	DB, err = Prepare(ctx, db.Conn)
-	return err
+	qs, err := Prepare(ctx, db.Conn)
+	if err != nil {
+		return err
+	}
+	*DB = *qs
+	return nil
 }

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -1,0 +1,11 @@
+package responses
+
+import "time"
+
+type Job struct {
+	Name             string    `json:"name"`
+	DeliveryStrategy string    `json:"delivery_strategy"`
+	Attempts         int16     `json:"attempts"`
+	Concurrency      int16     `json:"concurrency"`
+	CreatedAt        time.Time `json:"created_at"`
+}

--- a/server/enqueue_job_test.go
+++ b/server/enqueue_job_test.go
@@ -62,6 +62,8 @@ func Test401UnknownPassword(t *testing.T) {
 
 func Test400NoBody(t *testing.T) {
 	t.Parallel()
+	test.SetUp(t)
+	defer test.TearDown(t)
 	w := httptest.NewRecorder()
 	ejr := &EnqueueJobRequest{
 		Data: empty,
@@ -84,6 +86,8 @@ func Test400NoBody(t *testing.T) {
 
 func Test400EmptyBody(t *testing.T) {
 	t.Parallel()
+	test.SetUp(t)
+	defer test.TearDown(t)
 	w := httptest.NewRecorder()
 	var v interface{}
 	err := json.Unmarshal([]byte("{}"), &v)
@@ -92,7 +96,7 @@ func Test400EmptyBody(t *testing.T) {
 	json.NewEncoder(b).Encode(v)
 	ssa, server := newSSAServer()
 	ssa.AddUser("test", "password")
-	req, _ := http.NewRequest("PUT", "/v1/jobs/echo/job_f17373a6-2cd7-4010-afba-eebc6dc6f9ab", b)
+	req := httptest.NewRequest("PUT", "/v1/jobs/echo/job_f17373a6-2cd7-4010-afba-eebc6dc6f9ab", b)
 	req.SetBasicAuth("test", "password")
 	server.ServeHTTP(w, req)
 	test.AssertEquals(t, w.Code, http.StatusBadRequest)
@@ -106,6 +110,8 @@ func Test400EmptyBody(t *testing.T) {
 
 func Test400InvalidUUID(t *testing.T) {
 	t.Parallel()
+	test.SetUp(t)
+	defer test.TearDown(t)
 	w := httptest.NewRecorder()
 	ejr := &EnqueueJobRequest{
 		Data: empty,
@@ -125,6 +131,8 @@ func Test400InvalidUUID(t *testing.T) {
 
 func Test400WrongPrefix(t *testing.T) {
 	t.Parallel()
+	test.SetUp(t)
+	defer test.TearDown(t)
 	w := httptest.NewRecorder()
 	ejr := &EnqueueJobRequest{
 		Data: empty,
@@ -139,6 +147,8 @@ func Test400WrongPrefix(t *testing.T) {
 
 func Test413TooLargeJSON(t *testing.T) {
 	t.Parallel()
+	test.SetUp(t)
+	defer test.TearDown(t)
 	w := httptest.NewRecorder()
 	// 4 bytes per record - the value and the quotes around it.
 	var bigarr [100 * 256]string

--- a/server/regex_handler.go
+++ b/server/regex_handler.go
@@ -46,6 +46,10 @@ func (h *RegexpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, route := range h.routes {
 		if route.pattern.MatchString(r.URL.Path) {
 			upperMethod := strings.ToUpper(r.Method)
+			if route.methods == nil && upperMethod != "OPTIONS" {
+				route.handler.ServeHTTP(w, r)
+				return
+			}
 			for _, method := range route.methods {
 				if strings.ToUpper(method) == upperMethod {
 					route.handler.ServeHTTP(w, r)

--- a/server/v2.go
+++ b/server/v2.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/kevinburke/rest"
+	"github.com/kevinburke/rickover/dbtohttp"
+	"github.com/kevinburke/rickover/newmodels"
+)
+
+func V2(db *newmodels.Queries) http.Handler {
+	h := new(RegexpHandler)
+	// auth is handled external to this function
+	h.Handler(regexp.MustCompile(`^/v2/job-types$`), []string{"GET"}, v2GetJobTypes(db))
+	return h
+}
+
+// GET /v2/job-types
+//
+// List all job types.
+func v2GetJobTypes(db *newmodels.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		jobs, err := db.GetAllJobs(r.Context())
+		if err != nil {
+			rest.ServerError(w, r, err)
+			return
+		}
+		respond(Logger, w, r, dbtohttp.Jobs(jobs))
+	}
+}

--- a/services/enqueue.go
+++ b/services/enqueue.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/kevinburke/rickover/models/queued_jobs"
+	"github.com/kevinburke/rickover/newmodels"
+)
+
+// Enqueue creates a new queued job with the given ID and fields. A
+// sql.ErrNoRows will be returned if the `name` does not exist in the jobs
+// table. Otherwise the QueuedJob will be returned.
+func Enqueue(ctx context.Context, db *newmodels.Queries, params newmodels.EnqueueJobParams) (newmodels.QueuedJob, error) {
+	qj, err := db.EnqueueJob(ctx, params)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			e := &queued_jobs.UnknownOrArchivedError{
+				Err: fmt.Sprintf("Job type %s does not exist or the job with that id has already been archived", params.Name),
+			}
+			return newmodels.QueuedJob{}, e
+		}
+		return newmodels.QueuedJob{}, err
+	}
+	qj.ID.Prefix = queued_jobs.Prefix
+	return qj, err
+}

--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -209,8 +209,9 @@ func TestReplayQueuedJobFails(t *testing.T) {
 }
 
 func Test202SuccessfulEnqueue(t *testing.T) {
-	defer test.TearDown(t)
-	_ = factory.CreateJob(t, factory.SampleJob)
+	test.SetUp(t)
+	t.Cleanup(func() { test.TearDown(t) })
+	factory.CreateJob(t, factory.SampleJob)
 
 	expiry := time.Now().UTC().Add(5 * time.Minute)
 	w := httptest.NewRecorder()
@@ -221,7 +222,7 @@ func Test202SuccessfulEnqueue(t *testing.T) {
 
 	b := new(bytes.Buffer)
 	json.NewEncoder(b).Encode(ejr)
-	req, _ := http.NewRequest("PUT", "/v1/jobs/echo/job_6740b44e-13b9-475d-af06-979627e0e0d6", b)
+	req := httptest.NewRequest("PUT", "/v1/jobs/echo/job_6740b44e-13b9-475d-af06-979627e0e0d6", b)
 	req.SetBasicAuth("test", testPassword)
 	server.DefaultServer.ServeHTTP(w, req)
 	test.AssertEquals(t, w.Code, http.StatusAccepted)


### PR DESCRIPTION
Also start working on passing around a *newmodels.Queries instead of
hardcoding `*newmodels.DB` everywhere.

Add a new `responses` package that can help us get rid of `auto_id`
in the database response, which is something that we don't want to
expose.

Updates #8.