### PR TITLE
all: fewer allocations when enqueueing a job

### DIFF
--- a/db/queries/queued_jobs.sql
+++ b/db/queries/queued_jobs.sql
@@ -12,7 +12,7 @@ WHERE jobs.name = $2
 AND NOT EXISTS (
 	SELECT 1 FROM archived_jobs WHERE id = $1
 )
-RETURNING *;
+RETURNING attempts, status, created_at, updated_at;
 
 -- name: EnqueueJobFast :exec
 INSERT INTO queued_jobs (id,

--- a/models/queued_jobs/queued_jobs.go
+++ b/models/queued_jobs/queued_jobs.go
@@ -43,7 +43,7 @@ var StuckJobLimit = 100
 //
 // Deprecated: use services.Enqueue instead.
 func Enqueue(params newmodels.EnqueueJobParams) (*newmodels.QueuedJob, error) {
-	qj, err := newmodels.DB.EnqueueJob(context.TODO(), params)
+	jobrow, err := newmodels.DB.EnqueueJob(context.TODO(), params)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			e := &UnknownOrArchivedError{
@@ -53,7 +53,17 @@ func Enqueue(params newmodels.EnqueueJobParams) (*newmodels.QueuedJob, error) {
 		}
 		return nil, err
 	}
-	qj.ID.Prefix = Prefix
+	qj := newmodels.QueuedJob{
+		ID:        params.ID,
+		Name:      params.Name,
+		RunAfter:  params.RunAfter,
+		ExpiresAt: params.ExpiresAt,
+		Data:      params.Data,
+		Status:    jobrow.Status,
+		Attempts:  jobrow.Attempts,
+		CreatedAt: jobrow.CreatedAt,
+		UpdatedAt: jobrow.UpdatedAt,
+	}
 	return &qj, err
 }
 

--- a/services/enqueue.go
+++ b/services/enqueue.go
@@ -13,7 +13,7 @@ import (
 // sql.ErrNoRows will be returned if the `name` does not exist in the jobs
 // table. Otherwise the QueuedJob will be returned.
 func Enqueue(ctx context.Context, db *newmodels.Queries, params newmodels.EnqueueJobParams) (newmodels.QueuedJob, error) {
-	qj, err := db.EnqueueJob(ctx, params)
+	jobrow, err := db.EnqueueJob(ctx, params)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			e := &queued_jobs.UnknownOrArchivedError{
@@ -22,6 +22,17 @@ func Enqueue(ctx context.Context, db *newmodels.Queries, params newmodels.Enqueu
 			return newmodels.QueuedJob{}, e
 		}
 		return newmodels.QueuedJob{}, err
+	}
+	qj := newmodels.QueuedJob{
+		ID:        params.ID,
+		Name:      params.Name,
+		RunAfter:  params.RunAfter,
+		ExpiresAt: params.ExpiresAt,
+		Data:      params.Data,
+		Status:    jobrow.Status,
+		Attempts:  jobrow.Attempts,
+		CreatedAt: jobrow.CreatedAt,
+		UpdatedAt: jobrow.UpdatedAt,
 	}
 	qj.ID.Prefix = queued_jobs.Prefix
 	return qj, err

--- a/test/archived_jobs/archived_jobs_test.go
+++ b/test/archived_jobs/archived_jobs_test.go
@@ -37,7 +37,7 @@ func testCreateJobReturnsJob(t *testing.T) {
 	test.AssertEquals(t, aj.Attempts, int16(qj.Attempts))
 	test.AssertEquals(t, string(aj.Data), "{\"baz\": 17, \"foo\": [\"bar\", \"pik_345\"]}")
 	test.AssertEquals(t, aj.ExpiresAt.Valid, true)
-	test.AssertEquals(t, aj.ExpiresAt.Time, qj.ExpiresAt.Time)
+	test.AssertEquals(t, aj.ExpiresAt.Time.Round(time.Millisecond), qj.ExpiresAt.Time.Round(time.Millisecond))
 
 	diff := time.Since(aj.CreatedAt)
 	test.Assert(t, diff < 100*time.Millisecond, fmt.Sprintf("CreatedAt should be close to the current time, got %v", diff))


### PR DESCRIPTION
Reuse the input parameters instead of allocating more memory.