### PR TITLE
github: add daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Add a Dependabot configuration for the two dependency ecosystems this
repository currently uses in practice: GitHub Actions and Go modules.

Both update schedules are set to daily as requested. No other package
manifests are present in the repository, so no additional ecosystems
need coverage right now.

